### PR TITLE
[Bug Fix]: Fixed the same size for all the display images for the games

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1344,6 +1344,13 @@ main {
 }
 
 .project-img img {
+  width: 213.75px;
+  height: 123.37px;
+  object-fit: fill;
+  transition: var(--transition-1);
+}
+
+#controller {
   width: 100%;
   height: 100%;
   object-fit: cover;

--- a/index.html
+++ b/index.html
@@ -83,7 +83,7 @@
               <div class="project-item-icon-box">
                 <img
                   src="https://raw.githubusercontent.com/Tarikul-Islam-Anik/Animated-Fluent-Emojis/master/Emojis/Activities/Video%20Game.png"
-                  alt="Eye" width="3" />
+                  alt="Eye" width="3" id="controller" />
               </div>
 
               <img src="./assets/images/Master_Typing.png" alt="master tying game" loading="lazy">
@@ -105,7 +105,7 @@
               <div class="project-item-icon-box">
                 <img
                   src="https://raw.githubusercontent.com/Tarikul-Islam-Anik/Animated-Fluent-Emojis/master/Emojis/Activities/Video%20Game.png"
-                  alt="Eye" width="3" />
+                  alt="Eye" width="3" id="controller" />
               </div>
 
               <img src="./assets/images/Tilting_Maze.png" alt="tilting maze game" loading="lazy">
@@ -125,7 +125,7 @@
               <div class="project-item-icon-box">
                 <img
                   src="https://raw.githubusercontent.com/Tarikul-Islam-Anik/Animated-Fluent-Emojis/master/Emojis/Activities/Video%20Game.png"
-                  alt="Eye" width="3" />
+                  alt="Eye" width="3" id="controller" />
               </div>
 
               <img src="./assets/images/Simon-game.png" alt="simon game challenge" loading="lazy">
@@ -145,7 +145,7 @@
               <div class="project-item-icon-box">
                 <img
                   src="https://raw.githubusercontent.com/Tarikul-Islam-Anik/Animated-Fluent-Emojis/master/Emojis/Activities/Video%20Game.png"
-                  alt="Eye" width="3" />
+                  alt="Eye" width="3" id="controller" />
               </div>
 
               <img src="./assets/images/Snake_Game.png" alt="Snake Game" loading="lazy">
@@ -165,7 +165,7 @@
               <div class="project-item-icon-box">
                 <img
                   src="https://raw.githubusercontent.com/Tarikul-Islam-Anik/Animated-Fluent-Emojis/master/Emojis/Activities/Video%20Game.png"
-                  alt="Eye" width="3" />
+                  alt="Eye" width="3" id="controller" />
               </div>
          
 
@@ -190,7 +190,7 @@
               <div class="project-item-icon-box">
                 <img
                   src="https://raw.githubusercontent.com/Tarikul-Islam-Anik/Animated-Fluent-Emojis/master/Emojis/Activities/Video%20Game.png"
-                  alt="Eye" width="3" />
+                  alt="Eye" width="3" id="controller" />
               </div>
 
               <img src="./assets/images/Whack_a_Mole.png" alt="Dino Runner Game" loading="lazy">
@@ -210,7 +210,7 @@
               <div class="project-item-icon-box">
                 <img
                   src="https://raw.githubusercontent.com/Tarikul-Islam-Anik/Animated-Fluent-Emojis/master/Emojis/Activities/Video%20Game.png"
-                  alt="Eye" width="3" />
+                  alt="Eye" width="3" id="controller" />
               </div>
 
               <img src="./assets/images/Doraemon_Jump.png" alt="Dino Runner Game" loading="lazy">
@@ -230,7 +230,7 @@
               <div class="project-item-icon-box">
                 <img
                   src="https://raw.githubusercontent.com/Tarikul-Islam-Anik/Animated-Fluent-Emojis/master/Emojis/Activities/Video%20Game.png"
-                  alt="Eye" width="3" />
+                  alt="Eye" width="3" id="controller" />
               </div>
 
               <img src="./assets/images/Black_Jack.png" alt="Black Jack" loading="lazy">
@@ -250,7 +250,7 @@
               <div class="project-item-icon-box">
                 <img
                   src="https://raw.githubusercontent.com/Tarikul-Islam-Anik/Animated-Fluent-Emojis/master/Emojis/Activities/Video%20Game.png"
-                  alt="Eye" width="3" />
+                  alt="Eye" width="3" id="controller" />
               </div>
 
               <img src="./assets/images/MemoryGame.png" alt="Memory Game" loading="lazy">
@@ -270,7 +270,7 @@
               <div class="project-item-icon-box">
                 <img
                   src="https://raw.githubusercontent.com/Tarikul-Islam-Anik/Animated-Fluent-Emojis/master/Emojis/Activities/Video%20Game.png"
-                  alt="Eye" width="3" />
+                  alt="Eye" width="3" id="controller" />
               </div>
 
               <img src="./assets/images/Word_Guessing_Game.png" alt="Word Guessing Game" loading="lazy">
@@ -290,7 +290,7 @@
               <div class="project-item-icon-box">
                 <img
                   src="https://raw.githubusercontent.com/Tarikul-Islam-Anik/Animated-Fluent-Emojis/master/Emojis/Activities/Video%20Game.png"
-                  alt="Eye" width="3" />
+                  alt="Eye" width="3" id="controller" />
               </div>
 
               <img src="./assets/images/Ludo_Game.png" alt="Ludo Game" loading="lazy">
@@ -310,7 +310,7 @@
               <div class="project-item-icon-box">
                 <img
                   src="https://raw.githubusercontent.com/Tarikul-Islam-Anik/Animated-Fluent-Emojis/master/Emojis/Activities/Video%20Game.png"
-                  alt="Eye" width="3" />
+                  alt="Eye" width="3" id="controller" />
               </div>
 
               <img src="./assets/images/piano.png" alt="Piano Game" loading="lazy">
@@ -330,7 +330,7 @@
               <div class="project-item-icon-box">
                 <img
                   src="https://raw.githubusercontent.com/Tarikul-Islam-Anik/Animated-Fluent-Emojis/master/Emojis/Activities/Video%20Game.png"
-                  alt="Eye" width="3" />
+                  alt="Eye" width="3" id="controller" />
               </div>
 
               <img src="./assets/images/Atari_breakout.png" alt="Atari breakout " loading="lazy">
@@ -349,7 +349,7 @@
               <div class="project-item-icon-box">
                 <img
                   src="https://raw.githubusercontent.com/Tarikul-Islam-Anik/Animated-Fluent-Emojis/master/Emojis/Activities/Video%20Game.png"
-                  alt="Eye" width="3" />
+                  alt="Eye" width="3" id="controller" />
               </div>
 
               <img src="./assets/images/Chrome_dinosaur_runner.png" alt="Dino Game" loading="lazy">
@@ -369,7 +369,7 @@
               <div class="project-item-icon-box">
                 <img
                   src="https://raw.githubusercontent.com/Tarikul-Islam-Anik/Animated-Fluent-Emojis/master/Emojis/Activities/Video%20Game.png"
-                  alt="Eye" width="3" />
+                  alt="Eye" width="3" id="controller" />
               </div>
 
               <img src="./assets/images/Colour_Guessing_Game.png" alt="color Game" loading="lazy">
@@ -389,7 +389,7 @@
               <div class="project-item-icon-box">
                 <img
                   src="https://raw.githubusercontent.com/Tarikul-Islam-Anik/Animated-Fluent-Emojis/master/Emojis/Activities/Video%20Game.png"
-                  alt="Eye" width="3" />
+                  alt="Eye" width="3" id="controller" />
               </div>
 
               <img src="./assets/images/Guess_The_Number.png" alt="color Game" loading="lazy">
@@ -408,7 +408,7 @@
               <div class="project-item-icon-box">
                 <img
                   src="https://raw.githubusercontent.com/Tarikul-Islam-Anik/Animated-Fluent-Emojis/master/Emojis/Activities/Video%20Game.png"
-                  alt="Eye" width="3" />
+                  alt="Eye" width="3" id="controller" />
               </div>
 
               <img src="./assets/images/race_car.png" alt="race Game" loading="lazy">
@@ -427,7 +427,7 @@
               <div class="project-item-icon-box">
                 <img
                   src="https://raw.githubusercontent.com/Tarikul-Islam-Anik/Animated-Fluent-Emojis/master/Emojis/Activities/Video%20Game.png"
-                  alt="Eye" width="3" />
+                  alt="Eye" width="3" id="controller" />
               </div>
 
               <img src="./assets/images/Aim_Training.png" alt="aim Game" loading="lazy">
@@ -447,7 +447,7 @@
               <div class="project-item-icon-box">
                 <img
                   src="https://raw.githubusercontent.com/Tarikul-Islam-Anik/Animated-Fluent-Emojis/master/Emojis/Activities/Video%20Game.png"
-                  alt="Eye" width="3" />
+                  alt="Eye" width="3" id="controller" />
               </div>
 
               <img src="./assets/images/Alien_Shooter.png" alt="Alien Game" loading="lazy">
@@ -466,7 +466,7 @@
               <div class="project-item-icon-box">
                 <img
                   src="https://raw.githubusercontent.com/Tarikul-Islam-Anik/Animated-Fluent-Emojis/master/Emojis/Activities/Video%20Game.png"
-                  alt="Eye" width="3" />
+                  alt="Eye" width="3" id="controller" />
               </div>
 
               <img src="./assets/images/Fruit_Ninja_Thumbnail.png" alt="Alien Game" loading="lazy">
@@ -485,7 +485,7 @@
               <div class="project-item-icon-box">
                 <img
                   src="https://raw.githubusercontent.com/Tarikul-Islam-Anik/Animated-Fluent-Emojis/master/Emojis/Activities/Video%20Game.png"
-                  alt="Eye" width="3" />
+                  alt="Eye" width="3" id="controller" />
               </div>
 
               <img src="./assets/images/Doodle_Jump_Game.png" alt="Doodle Game" loading="lazy">
@@ -504,7 +504,7 @@
               <div class="project-item-icon-box">
                 <img
                   src="https://raw.githubusercontent.com/Tarikul-Islam-Anik/Animated-Fluent-Emojis/master/Emojis/Activities/Video%20Game.png"
-                  alt="Eye" width="3" />
+                  alt="Eye" width="3" id="controller" />
               </div>
 
               <img src="./assets/images/Alphabet.png" alt="Doodle Game" loading="lazy">
@@ -523,7 +523,7 @@
               <div class="project-item-icon-box">
                 <img
                   src="https://raw.githubusercontent.com/Tarikul-Islam-Anik/Animated-Fluent-Emojis/master/Emojis/Activities/Video%20Game.png"
-                  alt="Eye" width="3" />
+                  alt="Eye" width="3" id="controller" />
               </div>
 
               <img src="./assets/images/candy_crush.png" alt="Candy Crush" loading="lazy">
@@ -542,7 +542,7 @@
               <div class="project-item-icon-box">
                 <img
                   src="https://raw.githubusercontent.com/Tarikul-Islam-Anik/Animated-Fluent-Emojis/master/Emojis/Activities/Video%20Game.png"
-                  alt="Eye" width="3" />
+                  alt="Eye" width="3" id="controller" />
               </div>
 
               <img src="./assets/images/Word_Association.png" alt="word game" loading="lazy">
@@ -562,7 +562,7 @@
               <div class="project-item-icon-box">
                 <img
                   src="https://raw.githubusercontent.com/Tarikul-Islam-Anik/Animated-Fluent-Emojis/master/Emojis/Activities/Video%20Game.png"
-                  alt="Eye" width="3" />
+                  alt="Eye" width="3" id="controller" />
               </div>
 
               <img src="./assets/images/Tic_Tac_Toe.png" alt="tic tac toe " loading="lazy">
@@ -583,7 +583,7 @@
               <div class="project-item-icon-box">
                 <img
                   src="https://raw.githubusercontent.com/Tarikul-Islam-Anik/Animated-Fluent-Emojis/master/Emojis/Activities/Video%20Game.png"
-                  alt="Eye" width="3" />
+                  alt="Eye" width="3" id="controller" />
               </div>
 
               <img src="./assets/images/Flappy_Bird_Game.png" alt="Flappy bird " loading="lazy">
@@ -604,7 +604,7 @@
               <div class="project-item-icon-box">
                 <img
                   src="https://raw.githubusercontent.com/Tarikul-Islam-Anik/Animated-Fluent-Emojis/master/Emojis/Activities/Video%20Game.png"
-                  alt="Eye" width="3" />
+                  alt="Eye" width="3" id="controller" />
               </div>
 
               <img src="./assets/images/Trivia_It.png" alt="Trivia " loading="lazy">
@@ -624,7 +624,7 @@
               <div class="project-item-icon-box">
                 <img
                   src="https://raw.githubusercontent.com/Tarikul-Islam-Anik/Animated-Fluent-Emojis/master/Emojis/Activities/Video%20Game.png"
-                  alt="Eye" width="3" />
+                  alt="Eye" width="3" id="controller" />
               </div>
 
               <img src="./assets/images/Minesweeper.png" alt="Minesweeper " loading="lazy">
@@ -644,7 +644,7 @@
               <div class="project-item-icon-box">
                 <img
                   src="https://raw.githubusercontent.com/Tarikul-Islam-Anik/Animated-Fluent-Emojis/master/Emojis/Activities/Video%20Game.png"
-                  alt="Eye" width="3" />
+                  alt="Eye" width="3" id="controller" />
               </div>
 
               <img src="./assets/images/Dice_Game.png" alt="Dice_Game " loading="lazy">
@@ -664,7 +664,7 @@
               <div class="project-item-icon-box">
                 <img
                   src="https://raw.githubusercontent.com/Tarikul-Islam-Anik/Animated-Fluent-Emojis/master/Emojis/Activities/Video%20Game.png"
-                  alt="Eye" width="3" />
+                  alt="Eye" width="3" id="controller" />
               </div>
 
               <img src="./assets/images/Pac_man.png" alt="Dice_Game " loading="lazy">
@@ -684,7 +684,7 @@
               <div class="project-item-icon-box">
                 <img
                   src="https://raw.githubusercontent.com/Tarikul-Islam-Anik/Animated-Fluent-Emojis/master/Emojis/Activities/Video%20Game.png"
-                  alt="Eye" width="3" />
+                  alt="Eye" width="3" id="controller" />
               </div>
 
               <img src="./assets/images/Brick_Breaker.png" alt="Brick_Breaker " loading="lazy">
@@ -704,7 +704,7 @@
               <div class="project-item-icon-box">
                 <img
                   src="https://raw.githubusercontent.com/Tarikul-Islam-Anik/Animated-Fluent-Emojis/master/Emojis/Activities/Video%20Game.png"
-                  alt="Eye" width="3" />
+                  alt="Eye" width="3" id="controller" />
               </div>
 
               <img src="./assets/images/Magic_Square.JPG" alt="Magic Square " loading="lazy">
@@ -724,7 +724,7 @@
               <div class="project-item-icon-box">
                 <img
                   src="https://raw.githubusercontent.com/Tarikul-Islam-Anik/Animated-Fluent-Emojis/master/Emojis/Activities/Video%20Game.png"
-                  alt="Eye" width="3" />
+                  alt="Eye" width="3" id="controller" />
               </div>
 
               <img src="./assets/images/Fight_Game.png" alt="Fight Game " loading="lazy">
@@ -744,7 +744,7 @@
               <div class="project-item-icon-box">
                 <img
                   src="https://raw.githubusercontent.com/Tarikul-Islam-Anik/Animated-Fluent-Emojis/master/Emojis/Activities/Video%20Game.png"
-                  alt="Eye" width="3" />
+                  alt="Eye" width="3" id="controller" />
               </div>
 
               <img src="./assets/images/LightHouse.png" alt="Lighthouse " loading="lazy">
@@ -764,7 +764,7 @@
               <div class="project-item-icon-box">
                 <img
                   src="https://raw.githubusercontent.com/Tarikul-Islam-Anik/Animated-Fluent-Emojis/master/Emojis/Activities/Video%20Game.png"
-                  alt="Eye" width="3" />
+                  alt="Eye" width="3" id="controller" />
               </div>
 
               <img src="./assets/images/Lights_Out.png" alt="Lights_Out " loading="lazy">
@@ -784,7 +784,7 @@
               <div class="project-item-icon-box">
                 <img
                   src="https://raw.githubusercontent.com/Tarikul-Islam-Anik/Animated-Fluent-Emojis/master/Emojis/Activities/Video%20Game.png"
-                  alt="Eye" width="3" />
+                  alt="Eye" width="3" id="controller" />
               </div>
 
               <img src="./assets/images/Word_Scramble_Game.png" alt="Word Scramble Game " loading="lazy">
@@ -804,7 +804,7 @@
               <div class="project-item-icon-box">
                 <img
                   src="https://raw.githubusercontent.com/Tarikul-Islam-Anik/Animated-Fluent-Emojis/master/Emojis/Activities/Video%20Game.png"
-                  alt="Eye" width="3" />
+                  alt="Eye" width="3" id="controller" />
               </div>
 
               <img src="./assets/images/Tetris.png" alt="Tetris " loading="lazy">
@@ -826,7 +826,7 @@
               <div class="project-item-icon-box">
                 <img
                   src="https://raw.githubusercontent.com/Tarikul-Islam-Anik/Animated-Fluent-Emojis/master/Emojis/Activities/Video%20Game.png"
-                  alt="Eye" width="3" />
+                  alt="Eye" width="3" id="controller" />
               </div>
 
               <img src="./assets/images/Interactive_Quizzing.png" alt="Interactive_Quizzing " loading="lazy">
@@ -846,7 +846,7 @@
               <div class="project-item-icon-box">
                 <img
                   src="https://raw.githubusercontent.com/Tarikul-Islam-Anik/Animated-Fluent-Emojis/master/Emojis/Activities/Video%20Game.png"
-                  alt="Eye" width="3" />
+                  alt="Eye" width="3" id="controller" />
               </div>
 
               <img src="./assets/images/Planet_Defense.png" alt="Planet_Defense " loading="lazy">
@@ -866,7 +866,7 @@
               <div class="project-item-icon-box">
                 <img
                   src="https://raw.githubusercontent.com/Tarikul-Islam-Anik/Animated-Fluent-Emojis/master/Emojis/Activities/Video%20Game.png"
-                  alt="Eye" width="3" />
+                  alt="Eye" width="3" id="controller" />
               </div>
 
               <img src="./assets/images/rabbit.png" alt="Rabbit Rush " loading="lazy">
@@ -886,7 +886,7 @@
               <div class="project-item-icon-box">
                 <img
                   src="https://raw.githubusercontent.com/Tarikul-Islam-Anik/Animated-Fluent-Emojis/master/Emojis/Activities/Video%20Game.png"
-                  alt="Eye" width="3" />
+                  alt="Eye" width="3" id="controller" />
               </div>
 
               <img src="./assets/images/Wordle.png" alt="Wordle " loading="lazy">
@@ -906,7 +906,7 @@
               <div class="project-item-icon-box">
                 <img
                   src="https://raw.githubusercontent.com/Tarikul-Islam-Anik/Animated-Fluent-Emojis/master/Emojis/Activities/Video%20Game.png"
-                  alt="Eye" width="3" />
+                  alt="Eye" width="3" id="controller" />
               </div>
 
               <img src="./assets/images/Roll_Race.png" alt="Roll Race " loading="lazy">
@@ -926,7 +926,7 @@
               <div class="project-item-icon-box">
                 <img
                   src="https://raw.githubusercontent.com/Tarikul-Islam-Anik/Animated-Fluent-Emojis/master/Emojis/Activities/Video%20Game.png"
-                  alt="Eye" width="3" />
+                  alt="Eye" width="3" id="controller" />
               </div>
 
               <img src="./assets/images/Menja.png" alt="Menja " loading="lazy">
@@ -946,7 +946,7 @@
               <div class="project-item-icon-box">
                 <img
                   src="https://raw.githubusercontent.com/Tarikul-Islam-Anik/Animated-Fluent-Emojis/master/Emojis/Activities/Video%20Game.png"
-                  alt="Eye" width="3" />
+                  alt="Eye" width="3" id="controller" />
               </div>
 
               <img src="./assets/images/Typing_Speed_Test.png" alt="Typing_Speed_Test_Game " loading="lazy">
@@ -966,7 +966,7 @@
               <div class="project-item-icon-box">
                 <img
                   src="https://raw.githubusercontent.com/Tarikul-Islam-Anik/Animated-Fluent-Emojis/master/Emojis/Activities/Video%20Game.png"
-                  alt="Eye" width="3" />
+                  alt="Eye" width="3" id="controller" />
               </div>
 
               <img src="./assets/images/Tile_Game.jpg" alt="Tile Game " loading="lazy">
@@ -986,7 +986,7 @@
               <div class="project-item-icon-box">
                 <img
                   src="https://raw.githubusercontent.com/Tarikul-Islam-Anik/Animated-Fluent-Emojis/master/Emojis/Activities/Video%20Game.png"
-                  alt="Eye" width="3" />
+                  alt="Eye" width="3" id="controller" />
               </div>
 
               <img src="./assets/images/Stick_Hero.png" alt="stick hero " loading="lazy">
@@ -1007,7 +1007,7 @@
               <div class="project-item-icon-box">
                 <img
                   src="https://raw.githubusercontent.com/Tarikul-Islam-Anik/Animated-Fluent-Emojis/master/Emojis/Activities/Video%20Game.png"
-                  alt="Eye" width="3" />
+                  alt="Eye" width="3" id="controller" />
               </div>
 
               <img src="./assets/images/starwars.png" alt="Starwars character game " loading="lazy">
@@ -1027,7 +1027,7 @@
               <div class="project-item-icon-box">
                 <img
                   src="https://raw.githubusercontent.com/Tarikul-Islam-Anik/Animated-Fluent-Emojis/master/Emojis/Activities/Video%20Game.png"
-                  alt="Eye" width="3" />
+                  alt="Eye" width="3" id="controller" />
               </div>
 
               <img src="./assets/images/Traffic_Run.PNG" alt="Traffic_Run " loading="lazy">
@@ -1047,7 +1047,7 @@
               <div class="project-item-icon-box">
                 <img
                   src="https://raw.githubusercontent.com/Tarikul-Islam-Anik/Animated-Fluent-Emojis/master/Emojis/Activities/Video%20Game.png"
-                  alt="Eye" width="3" />
+                  alt="Eye" width="3" id="controller" />
               </div>
 
               <img src="./assets/images/Love Result Predictor.png" alt="Traffic_Run " loading="lazy">


### PR DESCRIPTION
## PR Description 📜
I have fixed a default size i.e. (213.75px X 123.37px) for all the images for the games uploaded by the contributors in the /assets/images folder ,previously all the images were of different size and the home page looked very odd but now everything is symmetric and perfect😊
Fixes #881 

<hr>
 
- [X] I follow [CONTRIBUTING GUIDELINE](https://github.com/kunjgit/GameZone/blob/main/.github/CONTRIBUTING_GUIDELINE.md) & [CODE OF CONDUCT](https://github.com/kunjgit/GameZone/blob/main/.github/CODE_OF_CONDUCT.md) of this project.
- [X] I have performed a self-review of my own code or work.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] My changes generates no new warnings.
- [X] I have followed proper naming convention showed in [CONTRIBUTING GUIDELINE](https://github.com/kunjgit/GameZone/blob/main/.github/CONTRIBUTING_GUIDELINE.md)
- [X] I have added screenshot for website preview in assets/images 
- [X] I have added entries for my game in main README.md
- [X] I have added README.md in my folder 
- [X] I have added working video of the game in README.md (optional)
- [X] I have specified the respective issue number for which I have requested the new game.


<hr>

<img width="785" alt="issue 881 resolved" src="https://github.com/kunjgit/GameZone/assets/85580785/a0b8c420-8a91-4a16-8fe8-2e60284f371e">
 
<br>