### PR TITLE
Add FontAwesome Icon for Eye Preview Button

### DIFF
--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -13,7 +13,7 @@ const generateLiTags = (gamesData) => {
             <a href="./Games/${gameUrl}">
               <figure class="project-img">
                 <div class="project-item-icon-box">
-                  <img id="joystick" src="https://raw.githubusercontent.com/Tarikul-Islam-Anik/Animated-Fluent-Emojis/master/Emojis/Activities/Video%20Game.png" alt="Eye" width="3" />
+                  <i id="joystick" alt="Eye" width="3" class="fa-solid fa-eye"></i>
                 </div>
                 <img src="./assets/images/${thumbnailUrl}" alt="${gameTitle}" loading="lazy">
               </figure>

--- a/index.html
+++ b/index.html
@@ -53,6 +53,11 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600&display=swap" rel="stylesheet">
 
+  <!-- 
+    - fontawesome link
+  -->
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-iecdLmaskl7CVkqkXNQ/ZH/XLlvWZOJyj7Yy7tcenmpD1ypASozpmT/E0iPtmFIB46ZmdtAc9eNBvH0H/ZpiBw==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+
 </head>
 <!-- Light-Dark theme SWITCH -->
 <p class="invert-color" style="margin-top: 30px; margin-left: 50px;">Light/Dark theme :</p>


### PR DESCRIPTION
## PR Description 📜
This PR fixes the bug regarding non-visibility of the Eye Button for preview of the games. I have added FontAwesome Icon for an eye instead of an image.

Fixes #1691 

<hr>
 
## Mark the task you have completed ✅

<!----Please delete options that are not relevant. In order to tick the check box just but x inside them for example [x] like this----->

- [x] I follow [CONTRIBUTING GUIDELINE](https://github.com/kunjgit/GameZone/blob/main/.github/CONTRIBUTING_GUIDELINE.md) & [CODE OF CONDUCT](https://github.com/kunjgit/GameZone/blob/main/.github/CODE_OF_CONDUCT.md) of this project.
- [x] I have performed a self-review of my own code or work.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generates no new warnings.
- [x] I have followed proper naming convention showed in [CONTRIBUTING GUIDELINE](https://github.com/kunjgit/GameZone/blob/main/.github/CONTRIBUTING_GUIDELINE.md)


<hr>

## Add your screenshots(Optional) 📸
![image](https://github.com/kunjgit/GameZone/assets/96565730/39884b10-0647-4753-b863-7f149a4f644c)




--- 
<br>

## Thank you soo much for contributing to our repository 💗