### PR TITLE
Fix bug causing Squared Lines to not open

### DIFF
--- a/assets/js/gamesData.json
+++ b/assets/js/gamesData.json
@@ -637,7 +637,7 @@
   },
   "126": {
     "gameTitle": "Squared Lines",
-    "gameUrl": "Squared Lines",
+    "gameUrl": "Squared_lines",
     "thumbnailUrl": "Squared Lines.webp"
   },
   "127": {


### PR DESCRIPTION
## PR Description 📜

Fixes #2722 

Game Number 126 i.e. Squared Line was not opening when clicked from the game list due to a naming error in the code. So, this pull request fixes the bug.

<hr>
 
## Mark the task you have completed ✅

<!----Please delete options that are not relevant. In order to tick the check box just but x inside them for example [x] like this----->

- [x] I follow [CONTRIBUTING GUIDELINE](https://github.com/kunjgit/GameZone/blob/main/.github/CONTRIBUTING_GUIDELINE.md) & [CODE OF CONDUCT](https://github.com/kunjgit/GameZone/blob/main/.github/CODE_OF_CONDUCT.md) of this project.
- [x] I have performed a self-review of my own code or work.
- [x] My changes generates no new warnings.

<hr>

## Add your screenshots(Optional) 📸

Error encountered:

![Squared_lines_Error](https://github.com/kunjgit/GameZone/assets/66111954/c3d5cebb-4f89-416e-b2b6-3672874cff6e)

Expected Outcome:

![working_game](https://github.com/kunjgit/GameZone/assets/66111954/64fe6d0f-279e-4313-9ee4-c4aec0b7077b)

--- 
<br>

## Thank you soo much for contributing to our repository 💗