### PR TITLE
Fixed the links to thumbnails in the game data json

### DIFF
--- a/assets/js/gamesData.json
+++ b/assets/js/gamesData.json
@@ -1919,22 +1919,22 @@
   "382": {
     "gameTitle": "HueHero",
     "gameUrl": "HueHero",
-    "thumbnailUrl": ""
+    "thumbnailUrl": "HueHero.png"
   },
   "383": {
     "gameTitle": "Puzzel_Winner",
     "gameUrl": "Puzzel_Winner",
-    "thumbnailUrl": "icon.png"
+    "thumbnailUrl": "Puzzel_Winner.png"
   },
   "384": {
     "gameTitle": "Emoji_Intruder",
     "gameUrl": "Emoji_Intruder",
-    "thumbnailUrl": ""
+    "thumbnailUrl": "Emoji_intruder.png"
   },
   "385": {
     "gameTitle": "Guess_The_Weapon",
     "gameUrl": "Guess_The_Weapon",
-    "thumbnailUrl": "icon.png"
+    "thumbnailUrl": "Guess_The_Weapon.png"
   }
   
   


### PR DESCRIPTION
## PR Description 📜

Please include summary related to the issue you have fixed and describe your PR in brief over here by specifying the issue number on which you were working below
Fixes #3091 
Thumbnails for some games were not rendering. Fixed it by updating the url to the image in the game data json file.
<hr>
 
## Mark the task you have completed ✅

<!----Please delete options that are not relevant. In order to tick the check box just but x inside them for example [x] like this----->

- [x] I follow [CONTRIBUTING GUIDELINE](https://github.com/kunjgit/GameZone/blob/main/.github/CONTRIBUTING_GUIDELINE.md) & [CODE OF CONDUCT](https://github.com/kunjgit/GameZone/blob/main/.github/CODE_OF_CONDUCT.md) of this project.
- [x] I have performed a self-review of my own code or work.
- [x] My changes generates no new warnings.
<hr>

## Add your screenshots(Optional) 📸
![image](https://github.com/kunjgit/GameZone/assets/140929748/4e365dcc-b4d2-4de0-8aae-75d86a10f56f)
![image](https://github.com/kunjgit/GameZone/assets/140929748/9981e192-efbf-4595-8534-7c6d232b31dd)

--- 
<br>
