### PR TITLE
Fixed gap in hero section and pagination

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -2480,6 +2480,7 @@ textarea.form-input::-webkit-resizer {
 #prev-page-tile,
 #next-page-tile {
   padding: 10px;
+  justify-content: center;
   background-color: rgb(104, 98, 232);
   background: linear-gradient(
     90deg,
@@ -2511,13 +2512,15 @@ textarea.form-input::-webkit-resizer {
   flex-wrap: wrap;
   margin-right: 5px;
   gap: 5px;
-  padding-top: 0%;
+  /* padding-top: 7%; */
+  margin-top: 5%;
 }
 
 /* pagination styling */
 .pagination_section .page-tile {
   /* border: 2px solid rosybrown; */
   font-size: 20px;
+  justify-content: center;
   color: wheat;
   padding: 5px 15px;
   cursor: pointer;
@@ -2617,7 +2620,7 @@ textarea.form-input::-webkit-resizer {
   height: auto;
   text-align: center;
   color: snow;
-  padding-bottom: 40%;
+  padding-bottom: 27%;
   padding-top: 10%;
 }
 


### PR DESCRIPTION
## PR Description 📜

Issue Description

There is too much space between the first heading in the website and the games section. This causes inconsistency between the users, since the first thing that they see is a blank website.


I have reduced the extra space and also increased the space in the pagination_section div for better user experience 
Fixes #3107

<hr>
 
## Mark the task you have completed ✅

<!----Please delete options that are not relevant. In order to tick the check box just but x inside them for example [x] like this----->

- [x] I follow [CONTRIBUTING GUIDELINE](https://github.com/kunjgit/GameZone/blob/main/.github/CONTRIBUTING_GUIDELINE.md) & [CODE OF CONDUCT](https://github.com/kunjgit/GameZone/blob/main/.github/CODE_OF_CONDUCT.md) of this project.
- [x] I have performed a self-review of my own code or work.
- [x] My changes generates no new warnings.
- [x] I have specified the respective issue number for which I have made changes to the website
- [x] Reduced extra space in the hero(main) section and increased some space in the pagination section


<hr>

## Add your screenshots(Optional) 📸

![Screenshot 2024-05-11 150623](https://github.com/kunjgit/GameZone/assets/167475552/1d06dd84-8325-44d4-9d3a-e806bf2153ee)
![Screenshot 2024-05-11 150634](https://github.com/kunjgit/GameZone/assets/167475552/a64b442c-067f-41fb-89e6-17c276733424)



--- 
<br>

## Thank you soo much for contributing to our repository 💗