### PR TITLE
thumbnail images for emoji_intruder and puzzel_winner

### DIFF
--- a/assets/js/gamesData.json
+++ b/assets/js/gamesData.json
@@ -1924,12 +1924,12 @@
   "383": {
     "gameTitle": "Puzzel_Winner",
     "gameUrl": "Puzzel_Winner",
-    "thumbnailUrl": "Puzzel_Winner.png"
+    "thumbnailUrl": "Puzzel_winner.png"
   },
   "384": {
     "gameTitle": "Emoji_Intruder",
     "gameUrl": "Emoji_Intruder",
-    "thumbnailUrl": "Emoji_intruder.png"
+    "thumbnailUrl": "Emoji_Intruder.png"
   },
   "385": {
     "gameTitle": "Guess_The_Weapon",


### PR DESCRIPTION
@kunjgit issue #3641 has been rectified.

![image](https://github.com/kunjgit/GameZone/assets/137604220/58af0ee9-de2a-42bd-a358-cdc19e94bd31)
