### PR TITLE
solve Dice images not shown #3730 issue

### DIFF
--- a/Games/Pig_game/script.js
+++ b/Games/Pig_game/script.js
@@ -51,7 +51,7 @@ btnRoll.addEventListener('click', function () {
 
         // 2. Display dice
         diceEl.classList.remove('hidden');
-        diceEl.src = `images/dice-${dice}.png`;
+        diceEl.src = `assets/images/dice-${dice}.png`;
 
         // 3. Check for rolled 1
         if (dice !== 1) {


### PR DESCRIPTION
## PR Description 📜

I have fixed the issue and now the image of the dice is shown.
**Fixes #3730**

<hr>
 
## Mark the task you have completed ✅

<!----Please delete options that are not relevant. In order to tick the check box just but x inside them for example [x] like this----->

- [x] I follow [CONTRIBUTING GUIDELINE](https://github.com/kunjgit/GameZone/blob/main/.github/CONTRIBUTING_GUIDELINE.md) & [CODE OF CONDUCT](https://github.com/kunjgit/GameZone/blob/main/.github/CODE_OF_CONDUCT.md) of this project.
- [x] I have performed a self-review of my own code or work.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generates no new warnings.
- [x] I have followed proper naming convention showed in [CONTRIBUTING GUIDELINE](https://github.com/kunjgit/GameZone/blob/main/.github/CONTRIBUTING_GUIDELINE.md)



<hr>

## Screenshot 📸

<img width="1070" alt="Screenshot 2024-05-25 at 6 17 30 PM" src="https://github.com/kunjgit/GameZone/assets/90901154/7f059a55-3c37-4b2f-9df4-cc0ca4cf509d">



--- 
<br>

## Thank you soo much for contributing to our repository 💗