### PR TITLE
Tie scores reverted back to zero on click of reset score button.

### DIFF
--- a/Games/Rock_Paper_Scissors/index.html
+++ b/Games/Rock_Paper_Scissors/index.html
@@ -32,6 +32,7 @@
     <button class="btn" onclick="
     userScore=0;
     computerScore=0;
+    tieScore=0;
     updateResult();
     ">Reset Score</button>
     <button class="but5 btn" onclick="


### PR DESCRIPTION
## PR Description 📜
The ties score is now changed back to zero on click of the reset score button in the rock paper scissors game.
Fixes #3865

<hr>
 
## Mark the task you have completed ✅

<!----Please delete options that are not relevant. In order to tick the check box just but x inside them for example [x] like this----->

- [x] I follow [CONTRIBUTING GUIDELINE](https://github.com/kunjgit/GameZone/blob/main/.github/CONTRIBUTING_GUIDELINE.md) & [CODE OF CONDUCT](https://github.com/kunjgit/GameZone/blob/main/.github/CODE_OF_CONDUCT.md) of this project.
- [x] I have performed a self-review of my own code or work.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generates no new warnings.
- [x] I have followed proper naming convention showed in [CONTRIBUTING GUIDELINE](https://github.com/kunjgit/GameZone/blob/main/.github/CONTRIBUTING_GUIDELINE.md)
- [x] I have added screenshot for website preview in assets/images 
- [x] I have added entries for my game in main README.md
- [x] I have added README.md in my folder 
- [x] I have specified the respective issue number for which I have requested the new game.


<hr>

## Add your screenshots(Optional) 📸




--- 
<br>

## Thank you soo much for contributing to our repository 💗