### PR TITLE
fix: 3d box game url

### DIFF
--- a/assets/js/gamesData.json
+++ b/assets/js/gamesData.json
@@ -587,7 +587,7 @@
   },
   "116": {
     "gameTitle": "3d Box",
-    "gameUrl": "3d_Box Game",
+    "gameUrl": "3d_Box_Game",
     "thumbnailUrl": "3d_Box.webp"
   },
   "117": {
@@ -1585,12 +1585,12 @@
     "gameUrl": "Lady_Tiger_Hunter",
     "thumbnailUrl": ""
   },
-   "316": {
+  "316": {
     "gameTitle": "Stone Paper Scissor",
     "gameUrl": "Stone_Paper_Scissor",
     "thumbnailUrl": "favicon.webp"
   },
-  
+
   "317": {
     "gameTitle": "Flashlight Pointer Game",
     "gameUrl": "Flashlight_Pointer_Game",
@@ -1940,155 +1940,134 @@
     "gameTitle": "Bulls_and_Cows",
     "gameUrl": "Bulls_and_Cows",
     "thumbnailUrl": "bulls-and-cows.png"
-
   },
-  "387":{
-
+  "387": {
     "gameTitle": "Earth_Guardian",
     "gameUrl": "Earth_Guardian",
     "thumbnailUrl": "Earth_Guardian.png"
   },
-  "388":{
-
-    "gameTitle" : "Technical_Mind_Game",
-    "gameUrl" :  "Technical_Mind_Game",
-    "thumbnailUrl" : "Technical_Mind_Game.png"
-},
-  "389":{
+  "388": {
+    "gameTitle": "Technical_Mind_Game",
+    "gameUrl": "Technical_Mind_Game",
+    "thumbnailUrl": "Technical_Mind_Game.png"
+  },
+  "389": {
     "gameTitle": "Memory Cards Game",
     "gameUrl": "Memory_Cards_Game",
     "thumbnailUrl": "Memory_Cards_Game.png"
   },
-  "390":{
+  "390": {
     "gameTitle": "escaperoom",
     "gameUrl": "escaperoom",
     "thumbnailUrl": "escaperoom.png"
   },
-  "391":{
+  "391": {
     "gameTitle": "Dice Roller",
     "gameUrl": "Dice_Roller",
     "thumbnailUrl": "Dice_Roller.png"
-
   },
-  "392":{
+  "392": {
     "gameTitle": "Dragon Tower",
     "gameUrl": "Dragon_Tower",
     "thumbnailUrl": "Dragon_Tower.png"
   },
-  "412":{
-
-  "gameTitle": "Chrome_Dino_Game",
+  "412": {
+    "gameTitle": "Chrome_Dino_Game",
     "gameUrl": "Chrome_Dino_Game",
     "thumbnailUrl": "Chrome_Dino_Game.png"
-
-
   },
 
-  "394":{ 
-   "gameTitle": "path finder puzzle",
-  "gameUrl": "path_finder",
-  "thumbnailUrl": "pathfinder.png"
+  "394": {
+    "gameTitle": "path finder puzzle",
+    "gameUrl": "path_finder",
+    "thumbnailUrl": "pathfinder.png"
   },
 
-  "401":{
-
+  "401": {
     "gameTitle": "Chess.com",
-      "gameUrl": "Chess.com",
-      "thumbnailUrl": "Chess.com.jpg"
-  
-  
-    },
-  "399":{
-
+    "gameUrl": "Chess.com",
+    "thumbnailUrl": "Chess.com.jpg"
+  },
+  "399": {
     "gameTitle": "Brick_and_Ball",
     "gameUrl": "Brick_and_Ball",
     "thumbnailUrl": "Brick_and_Ball.png"
-
   },
 
-"413":{
-
+  "413": {
     "gameTitle": "Dot Connect",
     "gameUrl": "Dot_Connect",
     "thumbnailUrl": "Dot_Connect.png"
-
-},
-
-"396":{
-  "gameTitle": "path finder puzzle",
-  "gameUrl": "path_finder",
-  "thumbnailUrl": "pathfinder.png"
-},
-"414":{
-  "gameTitle": "NameFate",
-  "gameUrl": "namefate",
-  "thumbnailUrl": "namefate.png"
-}
-,
-"393":{
-
-  "gameTitle": "Pop My Balloon",
-  "gameUrl": "Pop_My_Balloon",
-  "thumbnailUrl": "Pop_My_Balloon.png"
-
-},
-"397":{
-  "gameTitle": "Tower Stack",
-  "gameUrl": "Tower_Stack",
-  "thumbnailUrl": "Tower_Stack.png"
-
-},
-"395":{
-
-  "gameTitle": "Virtual Pet Game",
-  "gameUrl": "Virtual_Pet_Game",
-  "thumbnailUrl": "Virtual_Pet_Game.png"
-
-},
-"411":{ "gameTitle": "Tiny Fishing",
-"gameUrl": "Tiny_Fishing",
-"thumbnailUrl": "Tiny_Fishing.png"
-},
-"398":{
-  "gameTitle": "Shrek Vs Wild",
-  "gameUrl": "Shrek_Vs_Wild",
-  "thumbnailUrl": "Shrek_Vs_Wild.png"
-},
-"405":{
-  "gameTitle": "Candy_Crush_Saga",
-  "gameUrl": "Candy_Crush_Saga",
-  "thumbnailUrl": "Candy_Crush_Saga.png"
-},"419":{
-
-  "gameTitle": "16_Puzzle",
-  "gameUrl": "16_Puzzle",
-  "thumbnailUrl": "16_Puzzle.png"
-},
-"420":{
-  "gameTitle" : "Colour_Generator_Game",
-  "gameUrl": "Colour_Generator_Game",
-  "thumbnailUrl": "Colour_Generator_Game.png"
   },
-"406":{
-  "gameTitle": "Knife_hit",
-  "gameUrl": "Knife_hit",
-  "thumbnailUrl": "Knife_hit.png"
-},"415":{
-  "gameTitle": "Anagram_Checker_Game",
-  "gameUrl": "Anagram_Checker_Game",
-  "thumbnailUrl": "Anagram_Checker_Game.png"
 
-},
-"407":{
-  "gameTitle": "Screen_Pet_Game",
-  "gameUrl": "Screen_Pet_Game",
-  "thumbnailUrl": "Screen_Pet_Game.png"
-
-},"416":{
- "gameTitle": "Guess_The_Song",
-  "gameUrl": "Guess_The_Song",
-  "thumbnailUrl": "Guess_The_Song.png"
+  "396": {
+    "gameTitle": "path finder puzzle",
+    "gameUrl": "path_finder",
+    "thumbnailUrl": "pathfinder.png"
+  },
+  "414": {
+    "gameTitle": "NameFate",
+    "gameUrl": "namefate",
+    "thumbnailUrl": "namefate.png"
+  },
+  "393": {
+    "gameTitle": "Pop My Balloon",
+    "gameUrl": "Pop_My_Balloon",
+    "thumbnailUrl": "Pop_My_Balloon.png"
+  },
+  "397": {
+    "gameTitle": "Tower Stack",
+    "gameUrl": "Tower_Stack",
+    "thumbnailUrl": "Tower_Stack.png"
+  },
+  "395": {
+    "gameTitle": "Virtual Pet Game",
+    "gameUrl": "Virtual_Pet_Game",
+    "thumbnailUrl": "Virtual_Pet_Game.png"
+  },
+  "411": {
+    "gameTitle": "Tiny Fishing",
+    "gameUrl": "Tiny_Fishing",
+    "thumbnailUrl": "Tiny_Fishing.png"
+  },
+  "398": {
+    "gameTitle": "Shrek Vs Wild",
+    "gameUrl": "Shrek_Vs_Wild",
+    "thumbnailUrl": "Shrek_Vs_Wild.png"
+  },
+  "405": {
+    "gameTitle": "Candy_Crush_Saga",
+    "gameUrl": "Candy_Crush_Saga",
+    "thumbnailUrl": "Candy_Crush_Saga.png"
+  },
+  "419": {
+    "gameTitle": "16_Puzzle",
+    "gameUrl": "16_Puzzle",
+    "thumbnailUrl": "16_Puzzle.png"
+  },
+  "420": {
+    "gameTitle": "Colour_Generator_Game",
+    "gameUrl": "Colour_Generator_Game",
+    "thumbnailUrl": "Colour_Generator_Game.png"
+  },
+  "406": {
+    "gameTitle": "Knife_hit",
+    "gameUrl": "Knife_hit",
+    "thumbnailUrl": "Knife_hit.png"
+  },
+  "415": {
+    "gameTitle": "Anagram_Checker_Game",
+    "gameUrl": "Anagram_Checker_Game",
+    "thumbnailUrl": "Anagram_Checker_Game.png"
+  },
+  "407": {
+    "gameTitle": "Screen_Pet_Game",
+    "gameUrl": "Screen_Pet_Game",
+    "thumbnailUrl": "Screen_Pet_Game.png"
+  },
+  "416": {
+    "gameTitle": "Guess_The_Song",
+    "gameUrl": "Guess_The_Song",
+    "thumbnailUrl": "Guess_The_Song.png"
+  }
 }
-  
-}
-


### PR DESCRIPTION
## PR Description 📜
3D box game url was incorrect.

Fixes #4191  

don't mind the number of lines changed, Its just due to removal of unnecessay spaces and wrong indentation, that got automatically adjusted using prettier extension..
only line changed was 3d game url

<hr>
 
## Mark the task you have completed ✅

<!----Please delete options that are not relevant. In order to tick the check box just but x inside them for example [x] like this----->

  - [x] I follow [CONTRIBUTING GUIDELINE](https://github.com/kunjgit/GameZone/blob/main/.github/CONTRIBUTING_GUIDELINE.md) & [CODE OF CONDUCT](https://github.com/kunjgit/GameZone/blob/main/.github/CODE_OF_CONDUCT.md) of this project.
  - [x] I have performed a self-review of my own code or work.
  - [x] I have commented my code, particularly in hard-to-understand areas.
  - [x] My changes generates no new warnings.
  - [ ] I have followed proper naming convention showed in [CONTRIBUTING GUIDELINE](https://github.com/kunjgit/GameZone/blob/main/.github/CONTRIBUTING_GUIDELINE.md)
  - [x] I have added screenshot for website preview in assets/images 
  - [ ] I have added entries for my game in main README.md
  - [ ] I have added README.md in my folder 
  - [ ] I have added working video of the game in README.md (optional)
  - [x] I have specified the respective issue number for which I have requested the new game.
  

<hr>

## Add your screenshots(Optional) 📸
![image](https://github.com/kunjgit/GameZone/assets/126901961/4f41015e-06f7-4a72-b981-1ae150821f34)


Fixed it...
![image](https://github.com/kunjgit/GameZone/assets/126901961/f1832bdd-19b7-4178-ba3a-d83081efa5be)




--- 
<br>

## Thank you soo much for contributing to our repository 💗