### PR TITLE
fix: add restart button after game over (#5256)

### DIFF
--- a/Games/Minesweeper/index.html
+++ b/Games/Minesweeper/index.html
@@ -18,6 +18,6 @@
         <div id="board"></div>
         <br>
         <button id="flag-button">🚩</button>
-        <button id="restart-button" style="display: none;">Restart</button>
+        <button id="restart-button">Restart</button>
     </body>
 </html>

--- a/Games/Minesweeper/index.html
+++ b/Games/Minesweeper/index.html
@@ -18,5 +18,6 @@
         <div id="board"></div>
         <br>
         <button id="flag-button">🚩</button>
+        <button id="restart-button" style="display: none;">Restart</button>
     </body>
 </html>

--- a/Games/Minesweeper/script.js
+++ b/Games/Minesweeper/script.js
@@ -29,19 +29,25 @@ function setMines() {
 function startGame() {
     document.getElementById("mines-count").innerText = minesCount;
     document.getElementById("flag-button").addEventListener("click", setFlag);
-    setMines();
-for (let r = 0; r < rows; r++) {
-        let row = [];
-        for (let c = 0; c < columns; c++) {
-            let tile = document.createElement("div");
-            tile.id = r.toString() + "-" + c.toString();
-            tile.addEventListener("click", clickTile);
-            document.getElementById("board").append(tile);
-            row.push(tile);
-        }
-        board.push(row);
-    }
 
+    initializeBoard();
+}
+
+function initializeBoard() {
+
+    setMines();
+
+    for (let r = 0; r < rows; r++) {
+            let row = [];
+            for (let c = 0; c < columns; c++) {
+                let tile = document.createElement("div");
+                tile.id = r.toString() + "-" + c.toString();
+                tile.addEventListener("click", clickTile);
+                document.getElementById("board").append(tile);
+                row.push(tile);
+            }
+            board.push(row);
+        }
 }
 
 function setFlag() {

--- a/Games/Minesweeper/script.js
+++ b/Games/Minesweeper/script.js
@@ -103,6 +103,10 @@ function revealMines() {
             }
         }
     }
+    
+    const restartButton = document.getElementById("restart-button");
+    restartButton.innerText = "Restart";
+    restartButton.style.display = "block";
 }
 
 function checkMine(r, c) {
@@ -155,6 +159,10 @@ function checkMine(r, c) {
     if (tilesClicked == rows * columns - minesCount) {
         document.getElementById("mines-count").innerText = "Cleared";
         gameOver = true;
+
+        const restartButton = document.getElementById("restart-button");
+        restartButton.innerText = "AGAIN";
+        restartButton.style.display = "block";
     }
 
 }
@@ -180,6 +188,7 @@ function resetGame() {
     document.getElementById("board").innerHTML = "";
     document.getElementById("flag-button").style.backgroundColor = "lightgray";
     document.getElementById("mines-count").innerText = minesCount;
+    document.getElementById("restart-button").style.display = "none";
 
     startGame();
 }

--- a/Games/Minesweeper/script.js
+++ b/Games/Minesweeper/script.js
@@ -29,6 +29,7 @@ function setMines() {
 function startGame() {
     document.getElementById("mines-count").innerText = minesCount;
     document.getElementById("flag-button").addEventListener("click", setFlag);
+    document.getElementById("restart-button").addEventListener("click", resetGame);
 
     initializeBoard();
 }
@@ -175,4 +176,10 @@ function resetGame() {
     tilesClicked = 0;
     flagEnabled = false;
     gameOver = false;
+
+    document.getElementById("board").innerHTML = "";
+    document.getElementById("flag-button").style.backgroundColor = "lightgray";
+    document.getElementById("mines-count").innerText = minesCount;
+
+    startGame();
 }

--- a/Games/Minesweeper/script.js
+++ b/Games/Minesweeper/script.js
@@ -162,3 +162,11 @@ function checkTile(r, c) {
     }
     return 0;
 }
+
+function resetGame() {
+    board = [];
+    minesLocation = [];
+    tilesClicked = 0;
+    flagEnabled = false;
+    gameOver = false;
+}

--- a/Games/Minesweeper/styles.css
+++ b/Games/Minesweeper/styles.css
@@ -95,3 +95,7 @@ h1{
     left: 53%;
     transform: translate(-90%, -53%);
 }
+
+#restart-button {
+    display: none;
+}

--- a/Games/Minesweeper/styles.css
+++ b/Games/Minesweeper/styles.css
@@ -93,9 +93,19 @@ h1{
     position: absolute;
     top: 90%;
     left: 53%;
-    transform: translate(-90%, -53%);
+    transform: translate(-150%, -53%);
 }
 
 #restart-button {
-    display: none;
+    width: 100px;
+    height: 50px;
+    font-size: 25px;
+    background-color: lightgray;
+    color: rgb(201, 3, 3);
+    border: none;
+    border-radius: 10px;
+    position: absolute;
+    top: 90%;
+    left: 51%;
+    transform: translate(20px, -50%);
 }

--- a/Games/Minesweeper/styles.css
+++ b/Games/Minesweeper/styles.css
@@ -101,7 +101,7 @@ h1{
     height: 50px;
     font-size: 25px;
     background-color: lightgray;
-    color: rgb(201, 3, 3);
+    color: rgb(0, 0, 0);
     border: none;
     border-radius: 10px;
     position: absolute;


### PR DESCRIPTION
## PR Description 📜

This pull request implements the restart/again functionality for the Minesweeper game.

### Summary

- Added a restart button to the game interface.
- Implemented game reset functionality without requiring a page refresh.
- Refactored the board initialization logic for better code organization.
- Improved the layout and visibility of the flag and restart buttons.
- Updated the restart button text based on the game outcome:
  - **Restart** after a loss.
  - **AGAIN** after a win.

Fixes #5256

---

## Mark the task you have completed ✅

- [x] I follow [CONTRIBUTING GUIDELINE](https://github.com/kunjgit/GameZone/blob/main/.github/CONTRIBUTING_GUIDELINE.md) & [CODE OF CONDUCT](https://github.com/kunjgit/GameZone/blob/main/.github/CODE_OF_CONDUCT.md) of this project.
- [x] I have performed a self-review of my own code or work.
- [x] My changes generate no new warnings.
- [x] I have followed the proper naming conventions described in the CONTRIBUTING GUIDELINE.

### Testing

- Verified that the restart button appears after losing.
- Verified that the button displays **"AGAIN"** after winning.
- Verified that clicking the button resets the board and starts a new game.
- Verified that the restart button is hidden while a game is in progress.